### PR TITLE
chore: keep CI green on Dependabot PRs and bump pinned actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,11 @@ jobs:
         run: git branch --track main origin/main
 
       - name: Initialize the Nx Cloud distributed CI run and stop agents when the build tasks are done
+        if: github.actor != 'dependabot[bot]'
         run: npx nx-cloud start-ci-run --stop-agents-after=build
 
       - name: Run commands in parallel
+        if: github.actor != 'dependabot[bot]'
         run: |
           pids=()
           # list of commands to be run on main has env flag NX_CLOUD_DISTRIBUTED_EXECUTION set to false
@@ -67,7 +69,7 @@ jobs:
           # list of commands to be run on agents
           npx nx affected -t lint,test --parallel=4 &
           npx nx affected -t component-test --parallel=1 &
-          npx nx affected -t build --parallel=4 & 
+          npx nx affected -t build --parallel=4 &
           pids+=($!)
 
           # run all commands in parallel and bail if one of them fails
@@ -79,8 +81,22 @@ jobs:
 
           exit 0
 
+      # Dependabot PRs don't receive the NX_CLOUD_ACCESS_TOKEN secret, so the
+      # distributed agents never start. Run the same targets locally (no Nx
+      # Cloud) so lint/test/build still gate the PR instead of hanging/failing.
+      - name: Run commands locally (Dependabot)
+        if: github.actor == 'dependabot[bot]'
+        env:
+          NX_CLOUD_DISTRIBUTED_EXECUTION: false
+        run: |
+          npx nx format:check
+          npx nx affected -t lint,test,component-test,build --parallel=4
+
   agents:
     name: Agent ${{ matrix.agent }}
+    # Distributed agents require the Nx Cloud token, which Dependabot PRs
+    # cannot access; skip them so the run does not fail.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     name: Nx Cloud - Main Job
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.3
         name: Checkout [Pull Request]
         if: ${{ github.event_name == 'pull_request' }}
         with:
@@ -30,7 +30,7 @@ jobs:
           # We need to fetch all branches and commits so that Nx affected has a base to compare against.
           fetch-depth: 0
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.3
         name: Checkout [Default Branch]
         if: ${{ github.event_name != 'pull_request' }}
         with:
@@ -38,12 +38,12 @@ jobs:
           fetch-depth: 0
 
       # Set node/npm/yarn versions using volta
-      - uses: volta-cli/action@v4
+      - uses: volta-cli/action@v5.0.0
         with:
           package-json-path: '${{ github.workspace }}/package.json'
 
       - name: Use the package manager cache if available
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -88,15 +88,15 @@ jobs:
         agent: [1, 2, 3, 4]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
 
       # Set node/npm/yarn versions using volta
-      - uses: volta-cli/action@v4
+      - uses: volta-cli/action@v5.0.0
         with:
           package-json-path: '${{ github.workspace }}/package.json'
 
       - name: Use the package manager cache if available
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
           cache: 'npm'


### PR DESCRIPTION
## Context

Replicates the spirit of `jdwillmsen/usersrole#89` (the non-Nx sibling), **adapted to this Nx-monorepo's actual structure**. Most of the sibling's concrete fixes do **not** apply here because the files/jobs they targeted don't exist in this repo — see notes.

## What actually applies here

This repo has a single Nx Cloud `ci.yml`. There are **no** `actions/upload-artifact`/`download-artifact` steps, **no** generated `environment.ts` from an `ENVIRONMENT_FILE` secret (the env files are committed), and **no** Firebase-deploy or recorded-Cypress jobs in CI. So the artifact-bump and env-template-fallback fixes from the sibling are N/A. The applicable item is the secret-dependent-jobs problem.

## Changes

- **`ci: bump pinned GitHub Actions to latest releases`** — `actions/checkout@v4 → v6.0.3`, `actions/setup-node@v3 → v6.4.0`, `volta-cli/action@v4 → v5.0.0`. `setup-node@v3` runs on a deprecated Node runtime.
- **`ci: keep CI green on Dependabot PRs without Nx Cloud token`** — Dependabot PRs run with restricted permissions and don't get `NX_CLOUD_ACCESS_TOKEN`, so the distributed-execution `agents` job never comes up and the Nx Cloud orchestration in the main job can't run. Guard the `nx-cloud start-ci-run`/`record` steps and the entire `agents` job behind `github.actor != 'dependabot[bot]'`, and add a local non-cloud fallback that runs `format:check` plus the affected `lint,test,component-test,build` targets so Dependabot PRs are still gated.

## Notes / owner action needed

- **Dependabot is not actually configured on this repo yet.** Dependabot **alerts are disabled** and there is **no `.github/dependabot.yml`**, so no Dependabot update PRs exist today. CI has also never run (0 workflow runs; last push Nov 2023). This PR makes the workflow safe *for when* Dependabot/CI run, but doesn't enable Dependabot — enable alerts/security updates and add a `dependabot.yml` under repo settings if you want the update stream.
- **`nx.json` commits a read-write `nxCloudAccessToken`.** Because of that, Nx Cloud auth currently works even without the secret, but it means a read-write token is reachable from any PR context. Consider rotating it to a read-only CI token / moving it to the secret. Out of scope here.
- The local Dependabot fallback path is untested (CI has never executed); validate on the first Dependabot/CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)