### PR TITLE
Add About page

### DIFF
--- a/libs/usersrole-nx-app/main/src/lib/components/about/about.component.cy.ts
+++ b/libs/usersrole-nx-app/main/src/lib/components/about/about.component.cy.ts
@@ -1,0 +1,36 @@
+import { AboutComponent } from './about.component';
+
+describe(AboutComponent.name, () => {
+  it('renders', () => {
+    cy.mount(AboutComponent);
+  });
+
+  describe('Screen Sizes', () => {
+    testScreenSize('XSmall', 400, 400);
+    testScreenSize('Small', 800, 800);
+    testScreenSize('Medium', 1200, 900);
+    testScreenSize('Large', 1600, 1080);
+    testScreenSize('XLarge', 2560, 1440);
+  });
+});
+
+function testScreenSize(size: string, width: number, height: number) {
+  it(`should be setup properly on ${size} screen size`, () => {
+    cy.viewport(width, height);
+    cy.mount(AboutComponent);
+    cy.getByCy('about-container').should('be.visible');
+    cy.getByCy('title')
+      .should('be.visible')
+      .and('contain.text', 'About Users Role NX');
+    cy.getByCy('description').should('be.visible').and('not.be.empty');
+    cy.getByCy('stack-title').should('be.visible');
+    cy.getByCy('stack').should('be.visible');
+    cy.getByCy('angular-stack-item').should('be.visible');
+    cy.getByCy('nx-stack-item').should('be.visible');
+    cy.getByCy('firebase-stack-item').should('be.visible');
+    cy.getByCy('source-title').should('be.visible');
+    cy.getByCy('source-link')
+      .should('be.visible')
+      .and('have.attr', 'href', 'https://github.com/jdwillmsen/usersrole-nx');
+  });
+}

--- a/libs/usersrole-nx-app/main/src/lib/components/about/about.component.html
+++ b/libs/usersrole-nx-app/main/src/lib/components/about/about.component.html
@@ -1,0 +1,34 @@
+<div class="about-container" data-cy="about-container">
+  <h1 data-cy="title">About Users Role NX</h1>
+  <p data-cy="description">
+    Users Role NX is a template application for user authentication and
+    authorization. It provides sign in with Firebase and Google Identity
+    Platform, role based access control managed through Firebase Functions, and
+    a general site layout with header, collapsable sidebar/navigation, and main
+    content area. It is also a Progressive Web App (PWA) and can be installed on
+    mobile and desktop devices.
+  </p>
+  <h2 data-cy="stack-title">Technology Stack</h2>
+  <ul class="stack" data-cy="stack">
+    @for (item of stack; track item.name) {
+      <li
+        [attr.data-cy]="item.name.toLowerCase().split(' ')[0] + '-stack-item'"
+      >
+        <span class="stack-name">{{ item.name }} {{ item.version }}</span>
+        — {{ item.description }}
+      </li>
+    }
+  </ul>
+  <h2 data-cy="source-title">Source</h2>
+  <p data-cy="source">
+    This project is developed in the open. The source code, CI pipelines, and
+    issue tracker live on
+    <a
+      href="https://github.com/jdwillmsen/usersrole-nx"
+      target="_blank"
+      rel="noopener noreferrer"
+      data-cy="source-link"
+      >GitHub</a
+    >.
+  </p>
+</div>

--- a/libs/usersrole-nx-app/main/src/lib/components/about/about.component.scss
+++ b/libs/usersrole-nx-app/main/src/lib/components/about/about.component.scss
@@ -1,0 +1,21 @@
+.about-container {
+  padding: 16px;
+  max-width: 960px;
+
+  h1 {
+    margin: 0;
+  }
+
+  .stack {
+    margin: 0;
+    padding-left: 24px;
+
+    li {
+      margin-bottom: 8px;
+    }
+
+    .stack-name {
+      font-weight: 500;
+    }
+  }
+}

--- a/libs/usersrole-nx-app/main/src/lib/components/about/about.component.spec.ts
+++ b/libs/usersrole-nx-app/main/src/lib/components/about/about.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AboutComponent } from './about.component';
+
+describe('AboutComponent', () => {
+  let component: AboutComponent;
+  let fixture: ComponentFixture<AboutComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AboutComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AboutComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render a stack item for each technology', () => {
+    const items: NodeListOf<HTMLLIElement> =
+      fixture.nativeElement.querySelectorAll('.stack li');
+    expect(items.length).toBe(component.stack.length);
+  });
+});

--- a/libs/usersrole-nx-app/main/src/lib/components/about/about.component.ts
+++ b/libs/usersrole-nx-app/main/src/lib/components/about/about.component.ts
@@ -1,0 +1,49 @@
+import { Component } from '@angular/core';
+
+interface StackItem {
+  name: string;
+  version: string;
+  description: string;
+}
+
+@Component({
+  selector: 'usersrole-nx-about',
+  imports: [],
+  templateUrl: './about.component.html',
+  styleUrls: ['./about.component.scss'],
+})
+export class AboutComponent {
+  stack: StackItem[] = [
+    {
+      name: 'Angular',
+      version: '21',
+      description: 'Frontend framework with standalone components and signals',
+    },
+    {
+      name: 'Angular Material',
+      version: '21',
+      description: 'UI component library and theming system',
+    },
+    {
+      name: 'Nx',
+      version: '23',
+      description: 'Monorepo build system with caching and affected commands',
+    },
+    {
+      name: 'Firebase',
+      version: '12',
+      description:
+        'Authentication, Cloud Functions, and hosting for all deployments',
+    },
+    {
+      name: 'ag-grid',
+      version: '36',
+      description: 'Data grid used for the users and roles admin pages',
+    },
+    {
+      name: 'Jest & Cypress',
+      version: '',
+      description: 'Unit testing and component/end-to-end testing',
+    },
+  ];
+}

--- a/libs/usersrole-nx-app/main/src/lib/components/home/home.component.cy.ts
+++ b/libs/usersrole-nx-app/main/src/lib/components/home/home.component.cy.ts
@@ -52,5 +52,6 @@ function testScreenSize(size: string, width: number, height: number) {
     cy.getByCy('theme-tile').should('be.visible');
     cy.getByCy('users-tile').should('be.visible');
     cy.getByCy('roles-tile').should('be.visible');
+    cy.getByCy('about-tile').should('be.visible');
   });
 }

--- a/libs/usersrole-nx-app/main/src/lib/components/home/home.component.ts
+++ b/libs/usersrole-nx-app/main/src/lib/components/home/home.component.ts
@@ -72,5 +72,12 @@ export class HomeComponent {
       description: 'This is the home link and is currently being displayed.',
       access: ['Read', 'Admin', 'Manager'],
     },
+    {
+      title: 'About',
+      link: '/about',
+      description:
+        'This is a page for viewing information about this application and its technology stack.',
+      access: ['Everyone'],
+    },
   ];
 }

--- a/libs/usersrole-nx-app/main/src/lib/lib.routes.ts
+++ b/libs/usersrole-nx-app/main/src/lib/lib.routes.ts
@@ -1,5 +1,6 @@
 import { Route } from '@angular/router';
 import { HomeComponent } from './components/home/home.component';
+import { AboutComponent } from './components/about/about.component';
 import { authenticationRoutes } from '@usersrole-nx/authentication';
 import { authGuard } from '@usersrole-nx/core';
 
@@ -12,6 +13,11 @@ export const mainRoutes: Route[] = [
   {
     path: 'home',
     component: HomeComponent,
+    canActivate: [authGuard],
+  },
+  {
+    path: 'about',
+    component: AboutComponent,
     canActivate: [authGuard],
   },
   {

--- a/libs/usersrole-nx-app/main/src/lib/services/navigation/navigation.service.spec.ts
+++ b/libs/usersrole-nx-app/main/src/lib/services/navigation/navigation.service.spec.ts
@@ -25,7 +25,7 @@ describe('NavigationService', () => {
 
   it('should return all roleless navigation items if no roles are provided', () => {
     const items = navigationService.getNavigationItems();
-    expect(items.length).toBe(6);
+    expect(items.length).toBe(7);
   });
 
   it('should return all navigation items if all roles are provided', () => {
@@ -36,7 +36,7 @@ describe('NavigationService', () => {
     permissionServiceMockHasRole.mockReturnValue(true);
 
     const itemsWithUserRole = navigationService.getNavigationItems();
-    expect(itemsWithUserRole.length).toBe(9);
+    expect(itemsWithUserRole.length).toBe(10);
   });
 
   it('should return all navigation items but profile if admin role is provided', () => {
@@ -51,7 +51,7 @@ describe('NavigationService', () => {
     );
 
     const itemsWithNoRolesMatch = navigationService.getNavigationItems();
-    expect(itemsWithNoRolesMatch.length).toBe(8);
+    expect(itemsWithNoRolesMatch.length).toBe(9);
   });
 
   it('should return all navigation items but profile if manager role is provided', () => {
@@ -66,7 +66,7 @@ describe('NavigationService', () => {
     );
 
     const itemsWithNoRolesMatch = navigationService.getNavigationItems();
-    expect(itemsWithNoRolesMatch.length).toBe(8);
+    expect(itemsWithNoRolesMatch.length).toBe(9);
   });
 
   it('should return all navigation items but profile if read role is provided', () => {
@@ -81,7 +81,7 @@ describe('NavigationService', () => {
     );
 
     const itemsWithNoRolesMatch = navigationService.getNavigationItems();
-    expect(itemsWithNoRolesMatch.length).toBe(8);
+    expect(itemsWithNoRolesMatch.length).toBe(9);
   });
 
   it('should return all non admin navigation items if user role is provided', () => {
@@ -96,6 +96,6 @@ describe('NavigationService', () => {
     );
 
     const itemsWithNoRolesMatch = navigationService.getNavigationItems();
-    expect(itemsWithNoRolesMatch.length).toBe(7);
+    expect(itemsWithNoRolesMatch.length).toBe(8);
   });
 });

--- a/libs/usersrole-nx-app/main/src/lib/services/navigation/navigation.service.ts
+++ b/libs/usersrole-nx-app/main/src/lib/services/navigation/navigation.service.ts
@@ -58,6 +58,11 @@ export class NavigationService {
       title: 'Roles',
       roles: ['read', 'admin', 'manager'],
     },
+    {
+      path: '/about',
+      icon: 'info',
+      title: 'About',
+    },
   ];
 
   getNavigationItems() {


### PR DESCRIPTION
## Summary

Adds an About page to the main app:

- **`AboutComponent`** in the `main` lib — describes the application, lists the technology stack (Angular 21, Material, Nx 23, Firebase, ag-grid 36, Jest/Cypress), and links to the GitHub repository
- **Route** `/about` behind `authGuard`, alongside `/home`
- **Navigation item** (`info` icon), visible to all users (roleless)
- **Home tile** linking to the page

## Testing

- Jest spec (creation + one stack `<li>` per entry)
- Cypress component test mounting across five viewport sizes, asserting all `data-cy` sections
- Navigation service spec counts updated for the added roleless item
- Local run: lint, test, build all green for affected projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)