### PR TITLE
Prune functions package.json before firebase deploy

### DIFF
--- a/apps/usersrole-nx-functions/project.json
+++ b/apps/usersrole-nx-functions/project.json
@@ -59,8 +59,15 @@
       }
     },
     "deploy": {
-      "command": "firebase deploy --only functions:usersrole-nx-functions",
-      "dependsOn": ["build"]
+      "executor": "nx:run-commands",
+      "dependsOn": ["build"],
+      "options": {
+        "commands": [
+          "node tools/scripts/prepare-functions-deploy.mjs",
+          "firebase deploy --only functions:usersrole-nx-functions"
+        ],
+        "parallel": false
+      }
     }
   }
 }

--- a/tools/scripts/prepare-functions-deploy.mjs
+++ b/tools/scripts/prepare-functions-deploy.mjs
@@ -38,5 +38,7 @@ writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
 rmSync(`${distDir}/package-lock.json`, { force: true });
 
 console.log(
-  `Rewrote ${pkgPath} with runtime dependencies: ${Object.keys(dependencies).join(', ')}`,
+  `Rewrote ${pkgPath} with runtime dependencies: ${Object.keys(
+    dependencies,
+  ).join(', ')}`,
 );

--- a/tools/scripts/prepare-functions-deploy.mjs
+++ b/tools/scripts/prepare-functions-deploy.mjs
@@ -1,0 +1,42 @@
+// The esbuild executor's generated package.json lists every third-party
+// package reachable through the Nx graph (Angular, @nx/angular, ...), not
+// just what the bundle imports, and it always emits a lockfile that ends up
+// out of sync with that list — both break the Cloud Functions buildpack
+// install. Rewrite dependencies to the bare imports actually present in the
+// bundle and drop the lockfile so the buildpack runs a plain npm install.
+import { readFileSync, writeFileSync, rmSync } from 'node:fs';
+
+const distDir = 'dist/apps/usersrole-nx-functions';
+
+const bundle = readFileSync(`${distDir}/main.js`, 'utf8');
+const bareImports = new Set(
+  [...bundle.matchAll(/(?:from\s*|require\()\s*["']([^."'][^"']*)["']/g)].map(
+    ([, spec]) =>
+      spec.startsWith('@')
+        ? spec.split('/').slice(0, 2).join('/')
+        : spec.split('/')[0],
+  ),
+);
+
+const rootDeps = JSON.parse(readFileSync('package.json', 'utf8')).dependencies;
+const nodeBuiltins = /^node:/;
+const dependencies = {};
+for (const name of [...bareImports].sort()) {
+  if (nodeBuiltins.test(name)) continue;
+  if (!rootDeps[name]) {
+    throw new Error(
+      `Bundle imports "${name}" but it is not in root package.json dependencies`,
+    );
+  }
+  dependencies[name] = rootDeps[name];
+}
+
+const pkgPath = `${distDir}/package.json`;
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+pkg.dependencies = dependencies;
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+rmSync(`${distDir}/package-lock.json`, { force: true });
+
+console.log(
+  `Rewrote ${pkgPath} with runtime dependencies: ${Object.keys(dependencies).join(', ')}`,
+);


### PR DESCRIPTION
## Summary

Functions deploys were failing in Cloud Build even after the firebase-admin peer fix: the `@nx/esbuild` executor's `generatePackageJson` emits a `package.json` listing every third-party package reachable through the Nx project graph — the full Angular stack and even `@nx/angular` — as runtime dependencies of the Node functions bundle, plus a pruned lockfile that doesn't satisfy that dependency list (`generateLockfile` is hardcoded `true` in the executor, not configurable). The Cloud Functions buildpack's `npm ci` then fails with EUSAGE on every deploy.

This adds `tools/scripts/prepare-functions-deploy.mjs` as a first step of `usersrole-nx-functions:deploy`:

- scans `dist/.../main.js` for the bare module specifiers the bundle actually imports (esbuild `thirdParty: false` keeps them external, so they are the true runtime deps)
- rewrites the generated `package.json` dependencies to exactly those packages, with versions from the root `package.json`, throwing if an import can't be resolved there
- deletes the generated lockfile so the buildpack falls back to plain `npm install`

## Testing

- Ran the script against a fresh build: dependencies reduced to `body-parser, cors, express, express-rate-limit, firebase-admin, firebase-functions`
- `firebase deploy --only functions:usersrole-nx-functions` with the pruned manifest: **both functions (`api`, `beforecreated`) deployed successfully**

🤖 Generated with [Claude Code](https://claude.com/claude-code)