### PR TITLE
Fix 401 on reload (auth restore race) and gray snackbar severity colors

### DIFF
--- a/libs/usersrole-nx-app/core/src/lib/interceptors/auth-token/auth-token.interceptor.spec.ts
+++ b/libs/usersrole-nx-app/core/src/lib/interceptors/auth-token/auth-token.interceptor.spec.ts
@@ -22,7 +22,7 @@ describe('AuthTokenInterceptor', () => {
         AuthTokenInterceptor,
         {
           provide: AUTH,
-          useValue: {},
+          useValue: { authStateReady: () => Promise.resolve() },
         },
         AuthTokenHttpInterceptorProvider,
       ],
@@ -55,5 +55,20 @@ describe('AuthTokenInterceptor', () => {
       .subscribe();
 
     idToken$.next('mocked-id-token');
+  });
+
+  it('should pass the request through without an Authorization header when there is no idToken', (done) => {
+    const request = new HttpRequest('GET', 'https://example.com/data');
+    idToken$.next(null);
+
+    interceptor
+      .intercept(request, {
+        handle: (req: HttpRequest<unknown>) => {
+          expect(req.headers.has('Authorization')).toBe(false);
+          done();
+          return new Observable();
+        },
+      })
+      .subscribe();
   });
 });

--- a/libs/usersrole-nx-app/core/src/lib/interceptors/auth-token/auth-token.interceptor.ts
+++ b/libs/usersrole-nx-app/core/src/lib/interceptors/auth-token/auth-token.interceptor.ts
@@ -6,7 +6,7 @@ import {
   HttpInterceptor,
   HTTP_INTERCEPTORS,
 } from '@angular/common/http';
-import { Observable, switchMap, take } from 'rxjs';
+import { from, Observable, switchMap, take } from 'rxjs';
 import { Auth } from 'firebase/auth';
 import { idToken } from 'rxfire/auth';
 import { AUTH } from '../../firebase.tokens';
@@ -19,7 +19,11 @@ export class AuthTokenInterceptor implements HttpInterceptor {
     request: HttpRequest<unknown>,
     next: HttpHandler,
   ): Observable<HttpEvent<unknown>> {
-    return idToken(this.auth).pipe(
+    // Wait for Firebase to finish restoring the session first: on page
+    // reload idToken emits null before restoration completes, which sent
+    // the request unauthenticated and produced 401s for signed-in users.
+    return from(this.auth.authStateReady()).pipe(
+      switchMap(() => idToken(this.auth)),
       take(1),
       switchMap((idToken) => {
         let clone = request.clone();

--- a/libs/usersrole-nx-app/shared/src/lib/components/snackbar/_snackbar-theme.component.scss
+++ b/libs/usersrole-nx-app/shared/src/lib/components/snackbar/_snackbar-theme.component.scss
@@ -89,19 +89,19 @@
 @mixin _variant($type, $color, $color-contrast) {
   .#{$type}.mat-mdc-snack-bar-container {
     .mdc-snackbar__surface {
-      --mat-snackbar-container-color: #{color-mix(
+      --mat-snack-bar-container-color: #{color-mix(
           in srgb,
           $color 25%,
           transparent
         )};
-      --mat-snackbar-supporting-text-color: #{$color};
+      --mat-snack-bar-supporting-text-color: #{$color};
     }
   }
 
   .#{$type}.filled.mat-mdc-snack-bar-container {
     .mdc-snackbar__surface {
-      --mat-snackbar-container-color: #{$color};
-      --mat-snackbar-supporting-text-color: #{$color-contrast};
+      --mat-snack-bar-container-color: #{$color};
+      --mat-snack-bar-supporting-text-color: #{$color-contrast};
     }
   }
 
@@ -110,8 +110,8 @@
     border-radius: 4px;
 
     .mdc-snackbar__surface {
-      --mat-snackbar-container-color: #{transparent};
-      --mat-snackbar-supporting-text-color: #{$color};
+      --mat-snack-bar-container-color: #{transparent};
+      --mat-snack-bar-supporting-text-color: #{$color};
     }
   }
 }


### PR DESCRIPTION
## Summary

Two production regressions observed after the v2.0.0 deploy:

**1. 401 "Unauthorized" banner on page reload while signed in**

`AuthTokenInterceptor` subscribed to rxfire's `idToken` with `take(1)`. On a fresh page load, Firebase emits `null` first while it restores the persisted session, so the very first API call (`GET /users/<uid>`) was sent with no `Authorization` header and the functions API returned 401, which the error handler surfaced as an "Unauthorized" snackbar. The interceptor now awaits `auth.authStateReady()` (modular SDK) before taking the token, so requests fired during app bootstrap carry the restored credentials. Added a spec for the signed-out pass-through (no header attached).

**2. Snackbar severity colors dead (gray banner)**

Angular Material 21 renamed the snack-bar theme tokens from `--mat-snackbar-*` to `--mat-snack-bar-*`. The custom snackbar theme still set the old names, so error/success/warn/info variants all fell back to the default gray container. Renamed all six token overrides in `_snackbar-theme.component.scss`.

## Testing

- `nx affected -t lint,test,build` — 12 projects green
- New interceptor spec covers both token and no-token paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)