### PR TITLE
Rebuild About page to match the usersrole reference implementation

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,6 @@
 /.nx/cache
 /.nx/workspace-data
 .nx/self-healing
+
+# Regenerated at build time with JSON-style quoting; keep prettier away.
+libs/usersrole-nx-app/main/src/lib/generated/version-info.ts

--- a/apps/usersrole-nx/project.json
+++ b/apps/usersrole-nx/project.json
@@ -7,8 +7,16 @@
   "tags": [],
   "implicitDependencies": ["usersrole-nx-functions"],
   "targets": {
+    "generate-version-info": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "options": {
+        "command": "node tools/scripts/generate-version-info.mjs"
+      }
+    },
     "build": {
       "executor": "@angular-devkit/build-angular:browser",
+      "dependsOn": ["^build", "generate-version-info"],
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/apps/usersrole-nx",

--- a/libs/usersrole-nx-app/main/src/lib/components/about/about.component.cy.ts
+++ b/libs/usersrole-nx-app/main/src/lib/components/about/about.component.cy.ts
@@ -1,36 +1,40 @@
 import { AboutComponent } from './about.component';
+import { ActivatedRoute } from '@angular/router';
+import { VERSION_INFO } from '../../generated/version-info';
 
-describe(AboutComponent.name, () => {
-  it('renders', () => {
-    cy.mount(AboutComponent);
+describe('AboutComponent', () => {
+  beforeEach(() => {
+    cy.mount(AboutComponent, {
+      providers: [{ provide: ActivatedRoute, useValue: {} }],
+    });
   });
 
-  describe('Screen Sizes', () => {
-    testScreenSize('XSmall', 400, 400);
-    testScreenSize('Small', 800, 800);
-    testScreenSize('Medium', 1200, 900);
-    testScreenSize('Large', 1600, 1080);
-    testScreenSize('XLarge', 2560, 1440);
+  it('should mount', () => {
+    cy.getByCy('about-page').should('be.visible');
+  });
+
+  it('renders all four info cards', () => {
+    cy.getByCy('build-card').should('be.visible');
+    // Assert the live Angular runtime line, not a generated dep: the deps map
+    // is empty in the committed placeholder version-info.ts.
+    cy.getByCy('libraries-card')
+      .should('be.visible')
+      .and('contain.text', 'Angular (runtime)');
+    cy.getByCy('runtime-card').should('be.visible');
+    cy.getByCy('project-card')
+      .should('be.visible')
+      .and('contain.text', 'jdwillmsen/usersrole-nx');
+  });
+
+  it('renders the commit link only for non-dev builds', () => {
+    // version-info.ts is regenerated with a real commit whenever the app build
+    // target runs, so assert against whatever this test build compiled in.
+    if (VERSION_INFO.commit === 'dev') {
+      cy.getByCy('commit-link').should('not.exist');
+    } else {
+      cy.getByCy('commit-link')
+        .should('be.visible')
+        .and('contain.text', VERSION_INFO.commit);
+    }
   });
 });
-
-function testScreenSize(size: string, width: number, height: number) {
-  it(`should be setup properly on ${size} screen size`, () => {
-    cy.viewport(width, height);
-    cy.mount(AboutComponent);
-    cy.getByCy('about-container').should('be.visible');
-    cy.getByCy('title')
-      .should('be.visible')
-      .and('contain.text', 'About Users Role NX');
-    cy.getByCy('description').should('be.visible').and('not.be.empty');
-    cy.getByCy('stack-title').should('be.visible');
-    cy.getByCy('stack').should('be.visible');
-    cy.getByCy('angular-stack-item').should('be.visible');
-    cy.getByCy('nx-stack-item').should('be.visible');
-    cy.getByCy('firebase-stack-item').should('be.visible');
-    cy.getByCy('source-title').should('be.visible');
-    cy.getByCy('source-link')
-      .should('be.visible')
-      .and('have.attr', 'href', 'https://github.com/jdwillmsen/usersrole-nx');
-  });
-}

--- a/libs/usersrole-nx-app/main/src/lib/components/about/about.component.html
+++ b/libs/usersrole-nx-app/main/src/lib/components/about/about.component.html
@@ -1,34 +1,65 @@
-<div class="about-container" data-cy="about-container">
-  <h1 data-cy="title">About Users Role NX</h1>
-  <p data-cy="description">
-    Users Role NX is a template application for user authentication and
-    authorization. It provides sign in with Firebase and Google Identity
-    Platform, role based access control managed through Firebase Functions, and
-    a general site layout with header, collapsable sidebar/navigation, and main
-    content area. It is also a Progressive Web App (PWA) and can be installed on
-    mobile and desktop devices.
-  </p>
-  <h2 data-cy="stack-title">Technology Stack</h2>
-  <ul class="stack" data-cy="stack">
-    @for (item of stack; track item.name) {
-      <li
-        [attr.data-cy]="item.name.toLowerCase().split(' ')[0] + '-stack-item'"
-      >
-        <span class="stack-name">{{ item.name }} {{ item.version }}</span>
-        — {{ item.description }}
-      </li>
-    }
-  </ul>
-  <h2 data-cy="source-title">Source</h2>
-  <p data-cy="source">
-    This project is developed in the open. The source code, CI pipelines, and
-    issue tracker live on
-    <a
-      href="https://github.com/jdwillmsen/usersrole-nx"
-      target="_blank"
-      rel="noopener noreferrer"
-      data-cy="source-link"
-      >GitHub</a
-    >.
-  </p>
+<div class="about" data-cy="about-page">
+  <h1>About</h1>
+
+  <mat-card data-cy="build-card">
+    <mat-card-header><mat-card-title>Build</mat-card-title></mat-card-header>
+    <mat-card-content>
+      <p>Version: {{ info.app }}</p>
+      <p>
+        Commit:
+        @if (commitUrl) {
+          <a
+            [href]="commitUrl"
+            target="_blank"
+            rel="noopener"
+            data-cy="commit-link"
+            >{{ info.commit }}</a
+          >
+        } @else {
+          {{ info.commit }}
+        }
+      </p>
+      <p>Built: {{ info.builtAt }}</p>
+      <p>Environment: {{ info.env }}</p>
+    </mat-card-content>
+  </mat-card>
+
+  <mat-card data-cy="libraries-card">
+    <mat-card-header
+      ><mat-card-title
+        >Framework &amp; libraries</mat-card-title
+      ></mat-card-header
+    >
+    <mat-card-content>
+      <p>Angular (runtime): {{ angularVersion }}</p>
+      @for (dep of info.deps | keyvalue; track dep.key) {
+        <p>{{ dep.key }}: {{ dep.value }}</p>
+      }
+    </mat-card-content>
+  </mat-card>
+
+  <mat-card data-cy="runtime-card">
+    <mat-card-header><mat-card-title>Runtime</mat-card-title></mat-card-header>
+    <mat-card-content>
+      <p>Zoneless change detection: {{ zoneless ? 'enabled' : 'disabled' }}</p>
+      <p>App Check: {{ appCheck }}</p>
+      <p>Browser: {{ browser }}</p>
+      <p>Platform: {{ platform }}</p>
+    </mat-card-content>
+  </mat-card>
+
+  <mat-card data-cy="project-card">
+    <mat-card-header><mat-card-title>Project</mat-card-title></mat-card-header>
+    <mat-card-content>
+      <p>{{ project.description }}</p>
+      <p>Author: {{ project.author }}</p>
+      <p>License: {{ project.license }}</p>
+      <p>
+        Repository:
+        <a [href]="repoUrl" target="_blank" rel="noopener"
+          >jdwillmsen/usersrole-nx</a
+        >
+      </p>
+    </mat-card-content>
+  </mat-card>
 </div>

--- a/libs/usersrole-nx-app/main/src/lib/components/about/about.component.scss
+++ b/libs/usersrole-nx-app/main/src/lib/components/about/about.component.scss
@@ -1,21 +1,6 @@
-.about-container {
+.about {
   padding: 16px;
-  max-width: 960px;
-
-  h1 {
-    margin: 0;
-  }
-
-  .stack {
-    margin: 0;
-    padding-left: 24px;
-
-    li {
-      margin-bottom: 8px;
-    }
-
-    .stack-name {
-      font-weight: 500;
-    }
-  }
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }

--- a/libs/usersrole-nx-app/main/src/lib/components/about/about.component.spec.ts
+++ b/libs/usersrole-nx-app/main/src/lib/components/about/about.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AboutComponent } from './about.component';
+import { VersionInfo } from '../../generated/version-info';
 
 describe('AboutComponent', () => {
   let component: AboutComponent;
@@ -15,13 +16,49 @@ describe('AboutComponent', () => {
     fixture.detectChanges();
   });
 
+  // version-info.ts is regenerated with a real commit whenever the app build
+  // target runs, so tests must not assume the committed 'dev' placeholder.
+  function setInfo(overrides: Partial<VersionInfo>) {
+    (component as { info: VersionInfo }).info = {
+      ...component.info,
+      ...overrides,
+    };
+    fixture.detectChanges();
+  }
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render a stack item for each technology', () => {
-    const items: NodeListOf<HTMLLIElement> =
-      fixture.nativeElement.querySelectorAll('.stack li');
-    expect(items.length).toBe(component.stack.length);
+  it('renders all four info cards', () => {
+    const cards = [
+      'build-card',
+      'libraries-card',
+      'runtime-card',
+      'project-card',
+    ];
+    for (const card of cards) {
+      expect(
+        fixture.nativeElement.querySelector(`[data-cy="${card}"]`),
+      ).toBeTruthy();
+    }
+  });
+
+  it('links the commit to the repository for real builds', () => {
+    setInfo({ commit: 'abc1234' });
+    expect(component.commitUrl).toBe(
+      'https://github.com/jdwillmsen/usersrole-nx/commit/abc1234',
+    );
+    expect(
+      fixture.nativeElement.querySelector('[data-cy="commit-link"]'),
+    ).toBeTruthy();
+  });
+
+  it('hides the commit link for dev builds', () => {
+    setInfo({ commit: 'dev' });
+    expect(component.commitUrl).toBeNull();
+    expect(
+      fixture.nativeElement.querySelector('[data-cy="commit-link"]'),
+    ).toBeNull();
   });
 });

--- a/libs/usersrole-nx-app/main/src/lib/components/about/about.component.ts
+++ b/libs/usersrole-nx-app/main/src/lib/components/about/about.component.ts
@@ -1,49 +1,37 @@
-import { Component } from '@angular/core';
+import { Component, VERSION } from '@angular/core';
+import { KeyValuePipe } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { VERSION_INFO } from '../../generated/version-info';
 
-interface StackItem {
-  name: string;
-  version: string;
-  description: string;
-}
+const REPO_URL = 'https://github.com/jdwillmsen/usersrole-nx';
 
 @Component({
   selector: 'usersrole-nx-about',
-  imports: [],
+  imports: [MatCardModule, KeyValuePipe],
   templateUrl: './about.component.html',
   styleUrls: ['./about.component.scss'],
 })
 export class AboutComponent {
-  stack: StackItem[] = [
-    {
-      name: 'Angular',
-      version: '21',
-      description: 'Frontend framework with standalone components and signals',
-    },
-    {
-      name: 'Angular Material',
-      version: '21',
-      description: 'UI component library and theming system',
-    },
-    {
-      name: 'Nx',
-      version: '23',
-      description: 'Monorepo build system with caching and affected commands',
-    },
-    {
-      name: 'Firebase',
-      version: '12',
-      description:
-        'Authentication, Cloud Functions, and hosting for all deployments',
-    },
-    {
-      name: 'ag-grid',
-      version: '36',
-      description: 'Data grid used for the users and roles admin pages',
-    },
-    {
-      name: 'Jest & Cypress',
-      version: '',
-      description: 'Unit testing and component/end-to-end testing',
-    },
-  ];
+  readonly info = VERSION_INFO;
+  readonly repoUrl = REPO_URL;
+  readonly angularVersion = VERSION.full;
+
+  // Zoneless CD ships without zone.js; its absence confirms the mode at runtime.
+  readonly zoneless =
+    typeof (window as unknown as { Zone?: unknown }).Zone === 'undefined';
+  readonly appCheck = 'disabled'; // App Check is not configured for this app.
+  readonly browser = navigator.userAgent;
+  readonly platform = navigator.platform;
+
+  readonly project = {
+    description: 'Users role and authentication template application.',
+    author: 'Jake Willmsen',
+    license: 'MIT',
+  };
+
+  get commitUrl(): string | null {
+    return this.info.commit && this.info.commit !== 'dev'
+      ? `${this.repoUrl}/commit/${this.info.commit}`
+      : null;
+  }
 }

--- a/libs/usersrole-nx-app/main/src/lib/generated/version-info.ts
+++ b/libs/usersrole-nx-app/main/src/lib/generated/version-info.ts
@@ -1,0 +1,16 @@
+// Generated at build time by tools/scripts/generate-version-info.mjs. Do not edit.
+export interface VersionInfo {
+  app: string;
+  commit: string;
+  builtAt: string;
+  env: string;
+  deps: Record<string, string>;
+}
+
+export const VERSION_INFO: VersionInfo = {
+  app: '0.0.0',
+  commit: 'dev',
+  builtAt: 'unknown',
+  env: 'unknown',
+  deps: {},
+};

--- a/tools/scripts/generate-version-info.mjs
+++ b/tools/scripts/generate-version-info.mjs
@@ -1,0 +1,42 @@
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildVersionInfo } from './version-info.lib.mjs';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
+
+let commit = 'dev';
+try {
+  commit = execFileSync('git', ['rev-parse', '--short', 'HEAD'], { cwd: root })
+    .toString()
+    .trim();
+} catch {
+  // No git (e.g. exported source) — keep the 'dev' fallback.
+}
+
+const info = buildVersionInfo(pkg, {
+  commit,
+  builtAt: new Date().toISOString(),
+  env: process.env.NODE_ENV || 'unknown',
+});
+
+const file = `// Generated at build time by tools/scripts/generate-version-info.mjs. Do not edit.
+export interface VersionInfo {
+  app: string;
+  commit: string;
+  builtAt: string;
+  env: string;
+  deps: Record<string, string>;
+}
+
+export const VERSION_INFO: VersionInfo = ${JSON.stringify(info, null, 2)};
+`;
+
+const outDir = resolve(root, 'libs/usersrole-nx-app/main/src/lib/generated');
+mkdirSync(outDir, { recursive: true });
+writeFileSync(resolve(outDir, 'version-info.ts'), file);
+console.log(
+  `Wrote libs/usersrole-nx-app/main/src/lib/generated/version-info.ts (commit ${info.commit}, env ${info.env}).`,
+);

--- a/tools/scripts/version-info.lib.mjs
+++ b/tools/scripts/version-info.lib.mjs
@@ -1,0 +1,33 @@
+export const DEFAULT_ALLOW_LIST = [
+  '@angular/core',
+  '@angular/material',
+  '@angular/cdk',
+  'firebase',
+  'rxfire',
+  'ag-grid-community',
+  'rxjs',
+  'typescript',
+  'nx',
+];
+
+export function buildVersionInfo(
+  pkg,
+  options = {},
+  allowList = DEFAULT_ALLOW_LIST,
+) {
+  const allDeps = {
+    ...(pkg.dependencies || {}),
+    ...(pkg.devDependencies || {}),
+  };
+  const deps = {};
+  for (const name of allowList) {
+    if (allDeps[name]) deps[name] = allDeps[name];
+  }
+  return {
+    app: pkg.version || 'unknown',
+    commit: options.commit || 'dev',
+    builtAt: options.builtAt || 'unknown',
+    env: options.env || 'unknown',
+    deps,
+  };
+}


### PR DESCRIPTION
## Summary

The About page shipped in #5 was a static text page and did not match the implementation in the original [usersrole](https://github.com/jdwillmsen/usersrole) app. This ports that implementation:

- **Four mat-cards**: Build (version, commit link, built-at, environment), Framework & libraries (live `VERSION.full` plus allow-listed deps from `package.json`), Runtime (zoneless change detection probe, App Check status, browser, platform), Project (description, author, license, repository link)
- **Generated build metadata**: `tools/scripts/generate-version-info.mjs` (+ pure lib module, ported from the reference) rewrites `libs/.../generated/version-info.ts` with the current commit, timestamp, and dependency versions; wired as a `dependsOn` of the `usersrole-nx:build` target. A `dev` placeholder is committed so lint/test/CT work without running a build.
- Same `data-cy` contract as the reference (`about-page`, `build-card`, `libraries-card`, `runtime-card`, `project-card`, `commit-link`)

Deviations from the reference, both deliberate:
- App Check shows `disabled` (not configured in this app, unlike usersrole)
- Commit-link tests assert against the compiled-in `VERSION_INFO` instead of assuming the `dev` placeholder — in this workspace the build target regenerates the file mid-pipeline, so the placeholder assumption is flaky

## Testing

- `nx affected -t lint,test,build` — green (3 projects + deps)
- Generator smoke-tested: emits real commit + 9 allow-listed deps
- `nx format:check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)