### PR TITLE
Align package version with releases and add release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: node

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@usersrole-nx/source",
-  "version": "0.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@usersrole-nx/source",
-      "version": "0.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "21.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usersrole-nx/source",
-  "version": "0.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "scripts": {
     "format": "npx nx format:write --all"


### PR DESCRIPTION
## Summary

- **Bump `package.json`/`package-lock.json` to 2.1.0** — the manifest was stuck at 0.0.0 while GitHub releases advanced to v2.1.0, so the deployed About page showed "Version: 0.0.0". After this merge and a redeploy, the Build card reflects the released version.
- **Add release-please workflow** — on pushes to `main`, [release-please](https://github.com/googleapis/release-please) maintains a running release PR from conventional commits (this repo already uses them). Merging that PR bumps the version, updates `CHANGELOG.md`, tags, and publishes the GitHub release. Baselines from the existing `v2.1.0` tag.

Note: release PRs created with the default `GITHUB_TOKEN` don't trigger CI workflows (GitHub limitation) — close/reopen the release PR to run CI on it, or switch the workflow to a PAT later if that becomes annoying.

## Testing

- `npm version 2.1.0` applied to manifest + both lockfile version fields
- Prettier clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)