### PR TITLE
Label version-info environment as production

### DIFF
--- a/apps/usersrole-nx/project.json
+++ b/apps/usersrole-nx/project.json
@@ -20,6 +20,12 @@
     "build": {
       "executor": "@angular-devkit/build-angular:browser",
       "dependsOn": ["^build", "generate-version-info"],
+      "inputs": [
+        "production",
+        "^production",
+        "{workspaceRoot}/package.json",
+        { "runtime": "git rev-parse --short HEAD" }
+      ],
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/apps/usersrole-nx",

--- a/apps/usersrole-nx/project.json
+++ b/apps/usersrole-nx/project.json
@@ -11,7 +11,10 @@
       "executor": "nx:run-commands",
       "cache": false,
       "options": {
-        "command": "node tools/scripts/generate-version-info.mjs"
+        "command": "node tools/scripts/generate-version-info.mjs",
+        "env": {
+          "NODE_ENV": "production"
+        }
       }
     },
     "build": {


### PR DESCRIPTION
## Summary

The About page Build card showed "Environment: unknown" — `generate-version-info` reads `NODE_ENV`, which nothing in the nx pipeline sets. This sets `NODE_ENV=production` on the target via run-commands `env`. The only builds that leave the machine are production deploys; local dev builds are already identifiable by `commit: dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)