### PR TITLE
Register DI interceptors with HttpClient (fixes persistent 401s)

### DIFF
--- a/apps/usersrole-nx/src/app/app.component.cy.ts
+++ b/apps/usersrole-nx/src/app/app.component.cy.ts
@@ -7,6 +7,8 @@ import { ENVIRONMENT, FirestoreService } from '@usersrole-nx/core';
 import { AUTH } from '@usersrole-nx/core';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { SwUpdate } from '@angular/service-worker';
+import { EMPTY } from 'rxjs';
 
 describe(AppComponent.name, () => {
   beforeEach(() => {
@@ -34,6 +36,10 @@ describe(AppComponent.name, () => {
             firebase: {},
             functionsBaseUrl: '',
           },
+        },
+        {
+          provide: SwUpdate,
+          useValue: { isEnabled: false, versionUpdates: EMPTY },
         },
       ],
     }).overrideComponent(AppComponent, {

--- a/apps/usersrole-nx/src/app/app.component.spec.ts
+++ b/apps/usersrole-nx/src/app/app.component.spec.ts
@@ -6,6 +6,8 @@ import { HttpClientModule } from '@angular/common/http';
 import { ENVIRONMENT, FirestoreService } from '@usersrole-nx/core';
 import { AUTH } from '@usersrole-nx/core';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { SwUpdate } from '@angular/service-worker';
+import { EMPTY } from 'rxjs';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
@@ -20,6 +22,10 @@ describe('AppComponent', () => {
         {
           provide: FirestoreService,
           useValue: {},
+        },
+        {
+          provide: SwUpdate,
+          useValue: { isEnabled: false, versionUpdates: EMPTY },
         },
         {
           provide: AUTH,

--- a/apps/usersrole-nx/src/app/app.component.ts
+++ b/apps/usersrole-nx/src/app/app.component.ts
@@ -1,6 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { MainComponent } from '@usersrole-nx/main';
+import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
+import { filter } from 'rxjs';
 
 @Component({
   imports: [RouterModule, MainComponent],
@@ -8,4 +10,21 @@ import { MainComponent } from '@usersrole-nx/main';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent {}
+export class AppComponent {
+  private swUpdate = inject(SwUpdate);
+
+  constructor() {
+    // Without this, ngsw keeps serving the previous build until a second
+    // manual reload, so users kept hitting bugs already fixed in production.
+    if (this.swUpdate.isEnabled) {
+      this.swUpdate.versionUpdates
+        .pipe(
+          filter(
+            (event): event is VersionReadyEvent =>
+              event.type === 'VERSION_READY',
+          ),
+        )
+        .subscribe(() => document.location.reload());
+    }
+  }
+}

--- a/apps/usersrole-nx/src/app/app.config.ts
+++ b/apps/usersrole-nx/src/app/app.config.ts
@@ -11,7 +11,10 @@ import {
 import { appRoutes } from './app.routes';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { provideHttpClient } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFunctions } from 'firebase/functions';
@@ -35,7 +38,10 @@ export const appConfig: ApplicationConfig = {
   providers: [
     AuthTokenHttpInterceptorProvider,
     GlobalHttpErrorHandlerInterceptorProvider,
-    provideHttpClient(),
+    // The auth-token and error-handler interceptors are HTTP_INTERCEPTORS DI
+    // providers; without this opt-in the standalone HttpClient ignores them
+    // and every API request goes out unauthenticated.
+    provideHttpClient(withInterceptorsFromDi()),
     provideAnimations(),
     importProvidersFrom(MatSnackBarModule),
     { provide: FIREBASE_APP, useValue: firebaseApp },


### PR DESCRIPTION
## Summary

**Root cause of the persistent "Unauthorized" alerts**: `provideHttpClient()` does not pick up classic `HTTP_INTERCEPTORS` multi-providers unless `withInterceptorsFromDi()` is passed. Since the standalone-bootstrap migration in the platform upgrade, `AuthTokenHttpInterceptorProvider` and `GlobalHttpErrorHandlerInterceptorProvider` were registered in DI but never executed — every API request was sent without an `Authorization` header, producing a 401 on each initial page load regardless of auth state. (The earlier `authStateReady()` interceptor fix was correct but moot: the interceptor never ran.)

- `provideHttpClient(withInterceptorsFromDi())` restores both interceptors (auth token + global 403 handler)
- `AppComponent` now reloads on the service worker's `VERSION_READY` event, so clients pick up new deploys on the next load — previously ngsw served the stale previous build until a second manual refresh, which is why fixes that were already live kept "not working"

## Testing

- `nx affected -t lint,test,build` — green (app + main lib + deps)
- App component spec/CT updated with an `SwUpdate` stub

🤖 Generated with [Claude Code](https://claude.com/claude-code)